### PR TITLE
Dynamic Markdown output

### DIFF
--- a/iris/src/iris.c
+++ b/iris/src/iris.c
@@ -177,7 +177,9 @@ int iris_sanitize_path(const char* base_dir, const char* requested_path, char* f
   // Use a larger buffer for realpath since it can write up to PATH_MAX bytes
   char realpath_buffer[PATH_MAX];
   if (!realpath(resolved_path, realpath_buffer)) {
-    return 0;
+    // she'll be roight mate
+    strncpy(full_path, resolved_path, IRIS_MAX_PATH_SIZE - 1);
+    return 1;
   }
 
   // Check if the resolved path fits in our output buffer

--- a/iris/src/iris.c
+++ b/iris/src/iris.c
@@ -200,7 +200,11 @@ int iris_sanitize_path(const char* base_dir, const char* requested_path, char* f
   return 1;
 }
 
-int iris_start(const char* address, const char* directory, int port) {
+int iris_default_intercept(char* path) {
+
+};
+
+int iris_start_with_intercept(const char* address, const char* directory, int port, int (*intercept)(char*)) {
   // Resolve base directory to absolute path once
   char resolved_base_dir[IRIS_MAX_PATH_SIZE];
 
@@ -301,6 +305,7 @@ int iris_start(const char* address, const char* directory, int port) {
       continue;
     }
 
+    intercept(full_path);
     struct stat st;
     if (stat(full_path, &st) == 0) {
       if (S_ISDIR(st.st_mode)) {
@@ -327,4 +332,8 @@ int iris_start(const char* address, const char* directory, int port) {
 
   close(server_fd);
   return 0;
+}
+
+int iris_start(const char* address, const char* directory, int port) {
+  return iris_start_with_intercept(address, directory, port, iris_default_intercept);
 }

--- a/iris/src/iris.h
+++ b/iris/src/iris.h
@@ -80,6 +80,18 @@ int iris_sanitize_path(const char* base_dir, const char* requested_path, char* f
  */
 int iris_start(const char* address, const char* directory, int port);
 
+/*
+ * Start the Iris HTTP server with an interceptor function.
+ *
+ *
+ * @param address The address to bind to (e.g., "0.0.0.0").
+ * @param directory The directory from which to serve files.
+ * @param port The port number to listen on.
+ * @param intercept The function to intercept requests with.
+ * @return 0 on success, non-zero on error.
+ */
+int iris_start_with_intercept(const char* address, const char* directory, int port, int (*intercept)(char*));
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Depends on #1 

This is a really shitty first attempt at dynamically generating Markdown files. It makes `iris_sanitize_path` almost entirely useless and it doesn't respect the output directory flag.